### PR TITLE
Fixed bug where running clang-tidy when targeting earlier version of …

### DIFF
--- a/include/yatlib/any.hpp
+++ b/include/yatlib/any.hpp
@@ -23,23 +23,23 @@
 // to disable the macros that prevent the use of std::any on those systems.
 
 #ifdef YAT_APPLE_CXX17_TYPES_UNAVAILABLE
-  #if __has_include("__availability")
-  #include <__availability>
-  #endif
-  #include <__config>
+#if __has_include("__availability")
+#include <__availability>
+#endif
+#include <__config>
 
-  // Kill the compile error by redefining attribute macros to empty
-  #undef _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
-  #undef _LIBCPP_AVAILABILITY_BAD_ANY_CAST
+// Kill the compile error by redefining attribute macros to empty
+#undef _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
+#undef _LIBCPP_AVAILABILITY_BAD_ANY_CAST
 
-  #define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
-  #define _LIBCPP_AVAILABILITY_BAD_ANY_CAST
+#define _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST
+#define _LIBCPP_AVAILABILITY_BAD_ANY_CAST
 
-  #ifdef _LIBCPP_ANY
-    #error "This header must be imported prior to any <any> imports!"
-  #endif
+#if defined(_LIBCPP_ANY) && !defined(__clang_analyzer__)
+#error "This header must be imported prior to any <any> imports!"
+#endif
 
-  #include <any>
+#include <any>
 
 // Define the bad_any_cast functios that are not in libc++.so on
 // older versions of macOS
@@ -48,7 +48,7 @@ inline const char* std::bad_any_cast::what() const _NOEXCEPT {
   return "bad any cast";
 }
 #else
-  #include <any>
+#include <any>
 #endif  // YAT_APPLE_CXX17_TYPES_UNAVAILABLE
 
 namespace yat {

--- a/include/yatlib/filesystem.hpp
+++ b/include/yatlib/filesystem.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#ifdef _LIBCPP_FILESYSTEM
+#if defined(_LIBCPP_FILESYSTEM) && !defined(__clang_analyzer__)
 #error "This header must be imported prior to any <filesystem> imports!"
 #endif
 

--- a/include/yatlib/optional.hpp
+++ b/include/yatlib/optional.hpp
@@ -23,23 +23,23 @@
 // to disable the macros that prevent the use of std::optional on those systems.
 
 #ifdef YAT_APPLE_CXX17_TYPES_UNAVAILABLE
-  #if __has_include("__availability")
-  #include <__availability>
-  #endif
-  #include <__config>
+#if __has_include("__availability")
+#include <__availability>
+#endif
+#include <__config>
 
-  // Kill the compile error by redefining attribute macros to empty
-  #undef _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS
-  #undef _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS
+// Kill the compile error by redefining attribute macros to empty
+#undef _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS
+#undef _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS
 
-  #define _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS
-  #define _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS
+#define _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS
+#define _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS
 
-  #ifdef _LIBCPP_OPTIONAL
-    #error "This header must be imported prior to any <optional> imports!"
-  #endif
+#if defined(_LIBCPP_OPTIONAL) && !defined(__clang_analyzer__)
+#error "This header must be imported prior to any <optional> imports!"
+#endif
 
-  #include <optional>
+#include <optional>
 
 // Define the bad_optional_access functios that are not in libc++.so on
 // older versions of macOS
@@ -50,7 +50,7 @@ inline const char* std::bad_optional_access::what() const _NOEXCEPT {
   return "bad_optional_access";
 }
 #else
-  #include <optional>
+#include <optional>
 #endif  // YAT_APPLE_CXX17_TYPES_UNAVAILABLE
 
 namespace yat {

--- a/include/yatlib/variant.hpp
+++ b/include/yatlib/variant.hpp
@@ -23,23 +23,23 @@
 // to disable the macros that prevent the use of std::variant on those systems.
 
 #ifdef YAT_APPLE_CXX17_TYPES_UNAVAILABLE
-  #if __has_include("__availability")
-  #include <__availability>
-  #endif
-  #include <__config>
+#if __has_include("__availability")
+#include <__availability>
+#endif
+#include <__config>
 
-  // Kill the compile error by redefining attribute macros to empty
-  #undef _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
-  #undef _LIBCPP_AVAILABILITY_BAD_VARIANT_ACCESS
+// Kill the compile error by redefining attribute macros to empty
+#undef _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
+#undef _LIBCPP_AVAILABILITY_BAD_VARIANT_ACCESS
 
-  #define _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
-  #define _LIBCPP_AVAILABILITY_BAD_VARIANT_ACCESS
+#define _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS
+#define _LIBCPP_AVAILABILITY_BAD_VARIANT_ACCESS
 
-  #ifdef _LIBCPP_VARIANT
-    #error "This header must be imported prior to any <variant> imports!"
-  #endif
+#if defined(_LIBCPP_VARIANT) && !defined(__clang_analyzer__)
+#error "This header must be imported prior to any <variant> imports!"
+#endif
 
-  #include <variant>
+#include <variant>
 
 // Define the bad_variant_access::what() function that is not in libc++.so on
 // older versions of macOS
@@ -47,7 +47,7 @@ inline const char* std::bad_variant_access::what() const _NOEXCEPT {
   return "bad_variant_access";
 }
 #else
-  #include <variant>
+#include <variant>
 #endif  // YAT_APPLE_CXX17_TYPES_UNAVAILABLE
 
 namespace yat {


### PR DESCRIPTION
…macOS would cause compile errors